### PR TITLE
fix collections.abc in python 3.10

### DIFF
--- a/src/lime/io.py
+++ b/src/lime/io.py
@@ -21,7 +21,7 @@ import pandas as pd
 from sys import exit, stdout
 from pathlib import Path
 from distutils.util import strtobool
-from collections import Sequence
+from collections.abc import Sequence
 
 from astropy.io import fits
 from astropy.table import Table

--- a/src/lime/tables.py
+++ b/src/lime/tables.py
@@ -1,6 +1,6 @@
 import numpy as np
 from functools import partial
-from collections import Sequence
+from collections.abc import Sequence
 
 try:
     import pylatex


### PR DESCRIPTION
This merge request fixes the import of `Sequence` from `collections.abc` in Python 3.10