### PR TITLE
Fix a minor spelling issue

### DIFF
--- a/src/lime/inference/intensity_threshold.py
+++ b/src/lime/inference/intensity_threshold.py
@@ -93,7 +93,7 @@ class LineFinder:
             raise LiMe_Error(f'Please provide a continuum and std array to the function or run "Spectrum.fit.continuum"'
                              f' prior to the peak detection')
 
-        # Get indeces of peaks
+        # Get indices of peaks
         limit_threshold = sigma_threshold * continuum_std
         limit_threshold = continuum_array + limit_threshold if emission_shape else continuum_array + limit_threshold
         idcs_peaks, _ = signal.find_peaks(self._spec.flux, height=limit_threshold, distance=width_tol)

--- a/src/lime/observations.py
+++ b/src/lime/observations.py
@@ -1497,7 +1497,7 @@ class Cube:
         signal_slice = self.flux[idcsEmis, :, :]
         signal_slice = signal_slice.data
 
-        # Get indeces all nan entries to exclude them from the analysis
+        # Get indices all nan entries to exclude them from the analysis
         idcs_all_nan = np.all(np.isnan(signal_slice.data), axis=0)
 
         # If not mask parameter provided we use the flux percentiles
@@ -2097,7 +2097,7 @@ class Sample(UserDict, OpenFits):
         # Proceed to selection
         if valid_check:
 
-            # Check if Pandas indeces, numpy boolean or scalar key
+            # Check if Pandas indices, numpy boolean or scalar key
             if isinstance(id_key, pd.Index) or isinstance(id_key, pd.MultiIndex) or isinstance(id_key, pd.Series):
                 idcs = id_key
             elif isinstance(id_key, (np.ndarray, np.bool_)):

--- a/src/lime/plotting/bokeh_plots.py
+++ b/src/lime/plotting/bokeh_plots.py
@@ -596,7 +596,7 @@ class BokehFigures:
                                 counts, _ = np.histogram(self._spec.infer.conf_arr[idcs_feature], bins=bins)
                                 for idx_conf, count_conf in enumerate(counts):
                                     if count_conf > 0:
-                                        # Get indeces matching the detections
+                                        # Get indices matching the detections
                                         idcs_count = np.where((bins[idx_conf] < self._spec.infer.conf_arr[idcs_feature]) &
                                                               (self._spec.infer.conf_arr[idcs_feature] <= bins[
                                                                   idx_conf + 1]))[0]

--- a/src/lime/plotting/plots.py
+++ b/src/lime/plotting/plots.py
@@ -1208,7 +1208,7 @@ def spec_components_plotter(spec, ax, wave_plot, flux_plot, z_corr):
                 counts, _ = np.histogram(spec.infer.conf_arr[idcs_feature], bins=bins)
                 for idx_conf, count_conf in enumerate(counts):
                     if count_conf > 0:
-                        # Get indeces matching the detections
+                        # Get indices matching the detections
                         idcs_count = np.where((bins[idx_conf] < spec.infer.conf_arr[idcs_feature]) &
                                               (spec.infer.conf_arr[idcs_feature] <= bins[idx_conf + 1]))[0]
                         idcs_nonnan = np.where(idcs_feature)[0][idcs_count]  # Returns indices where mask is True

--- a/src/lime/tools.py
+++ b/src/lime/tools.py
@@ -112,7 +112,7 @@ def extract_fluxes(log, flux_type='mixture', sample_level='line', column_name='l
     if flux_type not in ('mixture', 'intg', 'profile'):
         raise LiMe_Error(f'Flux type "{flux_type}" is not recognized please one of "intg", "profile", or "mixture" ')
 
-    # Get indeces of blended lines
+    # Get indices of blended lines
     if not isinstance(log.index, pd.MultiIndex):
         idcs_blended = (log['group_label'] != 'none') & (~log.index.str.endswith('_m'))
     else:

--- a/src/lime/transitions.py
+++ b/src/lime/transitions.py
@@ -1737,7 +1737,7 @@ class Line:
         # Get the wavelength array and mask
         wave_arr = wavelength_array.data
 
-        # Find the indeces of the bands
+        # Find the indices of the bands
         idcs_bands = np.searchsorted(wave_arr, bands_obs_arr)
 
         # Return the boolean arrays

--- a/src/lime/workflow.py
+++ b/src/lime/workflow.py
@@ -52,7 +52,7 @@ def review_bands(spec, line, min_line_pixels=3, min_cont_pixels=2, user_cont_sou
                         f' a measurement.')
         return None
 
-    # Compute the line and adjacent continua indeces:
+    # Compute the line and adjacent continua indices:
     idcsEmis, idcsCont = line.index_bands(spec.wave, spec.redshift)
 
     if user_cont_source == 'fit':


### PR DESCRIPTION
In certain files, the term indices is mistakenly referred to as 'indeces,' which is not a commonly recognized spelling. This pull request changes that to the more recognized term 'indices.'