### PR TITLE
Fix inconsistent calling of other methods in voigt_area() method

### DIFF
--- a/src/lime/fitting/lines.py
+++ b/src/lime/fitting/lines.py
@@ -227,12 +227,8 @@ def lorentz_area(line, idx, n_steps):
 
 
 def voigt_area(line, idx, n_steps):
-
-    amp = np.random.normal(line.amp[idx], line.amp_err[idx], n_steps)
-    sigma = np.random.normal(line.sigma[idx], line.sigma_err[idx], n_steps)
-    gamma = np.random.normal(line.gamma[idx], line.gamma_err[idx], n_steps)
-
-    return gaussian_area(amp, sigma, n_steps) + lorentz_area(amp, gamma, n_steps)
+    
+    return gaussian_area(line, idx, n_steps) + lorentz_area(line, idx, n_steps)
 
 
 def pseudo_voigt_area(line, idx, n_steps):


### PR DESCRIPTION
lorentz_area and gaussian_area accept the parameters (line, idx) but voigt_area instead passes (amp, sigma) to those methods, leading to errors when lorentz_area attempted to access line attributes. A simple fix is to pass line and idx directly instead of calculating an amp and sigma.